### PR TITLE
[FEATURE] : FeedController 작성 및 포스트맨 테스트

### DIFF
--- a/src/main/java/com/example/ootd/domain/clothes/controller/ClothesController.java
+++ b/src/main/java/com/example/ootd/domain/clothes/controller/ClothesController.java
@@ -6,12 +6,14 @@ import com.example.ootd.domain.clothes.dto.request.ClothesSearchCondition;
 import com.example.ootd.domain.clothes.dto.request.ClothesUpdateRequest;
 import com.example.ootd.domain.clothes.service.ClothesService;
 import com.example.ootd.dto.PageResponse;
+import com.example.ootd.security.CustomUserDetails;
 import jakarta.validation.Valid;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
@@ -49,11 +51,15 @@ public class ClothesController {
   @PostMapping
   public ResponseEntity<ClothesDto> create(
       @RequestPart("request") ClothesCreateRequest request,
-      @RequestPart("image") MultipartFile image) {
+      @RequestPart(value = "image", required = false) MultipartFile image,
+      @AuthenticationPrincipal CustomUserDetails userDetails) { // Jwt 사용 시 null이 넘어와서 임시방편으로 CustomUserDetails 사용
 
-    log.info("의상 등록 요청: {}", request);
+    UUID userId = userDetails.getUser().getId();
 
-    ClothesDto response = clothesService.create(request, image);
+    log.info("의상 등록 요청: userId={}, request={}", userId, request);
+
+    // request의 ownerId null로 넘어옴 -> userId를 따로 받는 것으로 변경
+    ClothesDto response = clothesService.create(request, image, userId);
 
     log.debug("의상 등록 응답: {}", response);
 
@@ -79,8 +85,8 @@ public class ClothesController {
   @PatchMapping(path = "/{clothesId}")
   public ResponseEntity<ClothesDto> update(
       @PathVariable UUID clothesId,
-      @RequestPart("request") ClothesUpdateRequest request,
-      @RequestPart("image") MultipartFile image
+      @RequestPart(value = "request") ClothesUpdateRequest request,
+      @RequestPart(value = "image", required = false) MultipartFile image
   ) {
 
     log.info("의상 수정 요청: clothesId={}, request={}", clothesId, request);

--- a/src/main/java/com/example/ootd/domain/clothes/repository/custom/impl/CustomAttributeRepositoryImpl.java
+++ b/src/main/java/com/example/ootd/domain/clothes/repository/custom/impl/CustomAttributeRepositoryImpl.java
@@ -61,7 +61,7 @@ public class CustomAttributeRepositoryImpl implements CustomAttributeRepository 
   // 속성명, 속성 내용 검색
   private BooleanExpression getWhere(String keywordLike) {
 
-    if (StringUtils.hasText(keywordLike)) {
+    if (!StringUtils.hasText(keywordLike)) {
       return null;
     }
 
@@ -77,7 +77,7 @@ public class CustomAttributeRepositoryImpl implements CustomAttributeRepository 
 
     boolean isDesc = "DESCENDING".equalsIgnoreCase(condition.sortDirection());
 
-    if (!StringUtils.hasText(condition.cursor())) {
+    if (StringUtils.hasText(condition.cursor())) {
       switch (condition.sortBy()) {
         case "name":
           String cursorName = condition.cursor();

--- a/src/main/java/com/example/ootd/domain/clothes/repository/custom/impl/CustomClothesRepositoryImpl.java
+++ b/src/main/java/com/example/ootd/domain/clothes/repository/custom/impl/CustomClothesRepositoryImpl.java
@@ -74,8 +74,7 @@ public class CustomClothesRepositoryImpl implements CustomClothesRepository {
   // 커서(cursor) 세팅
   private BooleanExpression cursorCondition(String cursor, UUID idAfter) {
 
-    if (StringUtils.hasText(cursor)) {
-
+    if (!StringUtils.hasText(cursor)) {
       return afterCondition(idAfter);
     }
 

--- a/src/main/java/com/example/ootd/domain/clothes/service/ClothesService.java
+++ b/src/main/java/com/example/ootd/domain/clothes/service/ClothesService.java
@@ -14,7 +14,7 @@ import org.springframework.web.multipart.MultipartFile;
 public interface ClothesService {
 
   // 옷 등록
-  ClothesDto create(ClothesCreateRequest request, MultipartFile image);
+  ClothesDto create(ClothesCreateRequest request, MultipartFile image, UUID userId);
 
   // 옷 수정
   ClothesDto update(ClothesUpdateRequest request, MultipartFile image, UUID clothesId);

--- a/src/main/java/com/example/ootd/domain/clothes/service/impl/ClothesServiceImpl.java
+++ b/src/main/java/com/example/ootd/domain/clothes/service/impl/ClothesServiceImpl.java
@@ -47,12 +47,12 @@ public class ClothesServiceImpl implements ClothesService {
   private final ClothesMapper clothesMapper;
 
   @Override
-  public ClothesDto create(ClothesCreateRequest request, MultipartFile image) {
+  public ClothesDto create(ClothesCreateRequest request, MultipartFile image, UUID userId) {
 
     log.debug("의상 등록 시작: {}", request);
 
     Image clothesImage = imageService.upload(image);
-    User user = userRepository.findById(request.ownerId())
+    User user = userRepository.findById(userId)
         .orElseThrow(); // TODO: null 처리
 
     // Clothes 등록
@@ -205,7 +205,8 @@ public class ClothesServiceImpl implements ClothesService {
   }
 
   // 삭제 대상 속성 제거, 같은 id의 속성이 이미 존재할 경우
-  private void removeDeletedAttributes(Set<ClothesAttribute> currentAttributes, Set<UUID> incomingIds) {
+  private void removeDeletedAttributes(Set<ClothesAttribute> currentAttributes,
+      Set<UUID> incomingIds) {
     currentAttributes.removeIf(attr -> !incomingIds.contains(attr.getAttribute().getId()));
   }
 

--- a/src/main/java/com/example/ootd/domain/feed/controller/FeedController.java
+++ b/src/main/java/com/example/ootd/domain/feed/controller/FeedController.java
@@ -152,7 +152,7 @@ public class FeedController {
   @GetMapping(path = "/{feedId}/comments")
   public ResponseEntity<PageResponse<CommentDto>> findComment(
       @PathVariable UUID feedId,
-      @RequestBody FeedCommentSearchCondition condition
+      @ModelAttribute FeedCommentSearchCondition condition
   ) {
 
     log.info("피드 댓글 목록 조회 요청: feedId={}, request={}", feedId, condition);

--- a/src/main/java/com/example/ootd/domain/feed/controller/FeedController.java
+++ b/src/main/java/com/example/ootd/domain/feed/controller/FeedController.java
@@ -1,0 +1,182 @@
+package com.example.ootd.domain.feed.controller;
+
+import com.example.ootd.domain.feed.dto.data.CommentDto;
+import com.example.ootd.domain.feed.dto.data.FeedDto;
+import com.example.ootd.domain.feed.dto.request.CommentCreateRequest;
+import com.example.ootd.domain.feed.dto.request.FeedCommentSearchCondition;
+import com.example.ootd.domain.feed.dto.request.FeedCreateRequest;
+import com.example.ootd.domain.feed.dto.request.FeedSearchCondition;
+import com.example.ootd.domain.feed.dto.request.FeedUpdateRequest;
+import com.example.ootd.domain.feed.service.FeedService;
+import com.example.ootd.dto.PageResponse;
+import com.example.ootd.security.CustomUserDetails;
+import jakarta.validation.Valid;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping(path = "/api/feeds")
+public class FeedController {
+
+  private final FeedService feedService;
+
+  /**
+   * 피드
+   */
+  @GetMapping
+  public ResponseEntity<PageResponse<FeedDto>> findFeed(
+      @ModelAttribute @Valid FeedSearchCondition condition,
+      @AuthenticationPrincipal CustomUserDetails userDetails
+  ) {
+
+    UUID userId = userDetails.getUser().getId();
+
+    log.info("피드 목록 조회 요청: userId={}, request={}", userId, condition);
+
+    PageResponse<FeedDto> response = feedService.findFeedByCondition(condition, userId);
+
+    log.debug("피드 목록 조회 응답: feedCount={}", response.data().size());
+
+    return ResponseEntity
+        .status(HttpStatus.OK)
+        .body(response);
+  }
+
+  @PostMapping
+  public ResponseEntity<FeedDto> createFeed(@RequestBody FeedCreateRequest request) {
+
+    log.info("피드 등록 요청: {}", request);
+
+    FeedDto response = feedService.createFeed(request);
+
+    log.debug("피드 등록 응답: {}", response);
+
+    return ResponseEntity
+        .status(HttpStatus.CREATED)
+        .body(response);
+  }
+
+  @DeleteMapping(path = "/{feedId}")
+  public ResponseEntity<Void> deleteFeed(@PathVariable UUID feedId) {
+
+    log.info("피드 삭제 요청: feedId={}", feedId);
+
+    feedService.deleteFeed(feedId);
+
+    log.debug("피드 삭제 완료 응답");
+
+    return ResponseEntity
+        .status(HttpStatus.NO_CONTENT)
+        .build();
+  }
+
+  @PatchMapping(path = "/{feedId}")
+  public ResponseEntity<FeedDto> updateFeed(
+      @PathVariable UUID feedId,
+      @RequestBody FeedUpdateRequest request,
+      @AuthenticationPrincipal CustomUserDetails userDetails
+  ) {
+
+    UUID userId = userDetails.getUser().getId();
+
+    log.info("피드 수정 요청: feedId={}, userId={}, request={}", feedId, userId, request);
+
+    FeedDto response = feedService.updateFeed(feedId, request, userId);
+
+    log.debug("피드 수정 응답: {}", response);
+
+    return ResponseEntity
+        .status(HttpStatus.OK)
+        .body(response);
+  }
+
+  /**
+   * 피드 좋아요
+   */
+  @PostMapping(path = "/{feedId}/like")
+  public ResponseEntity<FeedDto> createLike(
+      @PathVariable UUID feedId,
+      @AuthenticationPrincipal CustomUserDetails userDetails
+  ) {
+
+    UUID userId = userDetails.getUser().getId();
+
+    log.info("피드 좋아요 등록 요청: feedId={}, userId={}", feedId, userId);
+
+    FeedDto response = feedService.likeFeed(feedId, userId);
+
+    log.debug("피드 좋아요 등록 응답: {}", response);
+
+    return ResponseEntity
+        .status(HttpStatus.CREATED)
+        .body(response);
+  }
+
+  @DeleteMapping(path = "/{feedId}/like")
+  public ResponseEntity<FeedDto> deleteLike(
+      @PathVariable UUID feedId,
+      @AuthenticationPrincipal CustomUserDetails userDetails
+  ) {
+
+    UUID userId = userDetails.getUser().getId();
+
+    log.info("피드 좋아요 삭제 요청: feedId={}, userId={}", feedId, userId);
+
+    feedService.deleteFeedLike(feedId, userId);
+
+    log.debug("피드 좋아요 삭제 완료");
+
+    return ResponseEntity
+        .status(HttpStatus.NO_CONTENT)
+        .build();
+  }
+
+  /**
+   * 피드 댓글
+   */
+  @GetMapping(path = "/{feedId}/comments")
+  public ResponseEntity<PageResponse<CommentDto>> findComment(
+      @PathVariable UUID feedId,
+      @RequestBody FeedCommentSearchCondition condition
+  ) {
+
+    log.info("피드 댓글 목록 조회 요청: feedId={}, request={}", feedId, condition);
+
+    PageResponse<CommentDto> response = feedService.findCommentByCondition(feedId, condition);
+
+    log.debug("피드 댓글 목록 조회 응답: commentCount={}", response.data().size());
+
+    return ResponseEntity
+        .status(HttpStatus.OK)
+        .body(response);
+  }
+
+  @PostMapping(path = "/{feedId}/comments")
+  public ResponseEntity<CommentDto> createComment(@RequestBody CommentCreateRequest request) {
+
+    log.info("피드 댓글 등록 요청: {}", request);
+
+    CommentDto response = feedService.createComment(request);
+
+    log.debug("피드 댓글 등록 응답: {}", response);
+
+    return ResponseEntity
+        .status(HttpStatus.CREATED)
+        .body(response);
+  }
+}

--- a/src/main/java/com/example/ootd/domain/feed/repository/FeedCommentRepository.java
+++ b/src/main/java/com/example/ootd/domain/feed/repository/FeedCommentRepository.java
@@ -1,30 +1,14 @@
 package com.example.ootd.domain.feed.repository;
 
 import com.example.ootd.domain.feed.entity.FeedComment;
-import java.time.LocalDateTime;
-import java.util.List;
+import com.example.ootd.domain.feed.repository.custom.CustomFeedCommentRepository;
 import java.util.UUID;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-public interface FeedCommentRepository extends JpaRepository<FeedComment, UUID> {
-
-  @Query("""
-      SELECT fc
-        FROM FeedComment fc
-       WHERE fc.feed.id = :feedId 
-             AND ((fc.createdAt > :cursor)
-                    OR (fc.createdAt = :cursor AND fc.id > :idAfter))
-       ORDER BY fc.createdAt asc, fc.id asc
-      """)
-  List<FeedComment> findByCondition(
-      @Param("feedId") UUID feedId,
-      @Param("cursor") LocalDateTime cursor,
-      @Param("idAfter") UUID idAfter,
-      Pageable pageable
-  );
+public interface FeedCommentRepository extends JpaRepository<FeedComment, UUID>,
+    CustomFeedCommentRepository {
 
   @Query("""
       SELECT count(fc.id)

--- a/src/main/java/com/example/ootd/domain/feed/repository/custom/CustomFeedCommentRepository.java
+++ b/src/main/java/com/example/ootd/domain/feed/repository/custom/CustomFeedCommentRepository.java
@@ -1,0 +1,10 @@
+package com.example.ootd.domain.feed.repository.custom;
+
+import com.example.ootd.domain.feed.dto.request.FeedCommentSearchCondition;
+import com.example.ootd.domain.feed.entity.FeedComment;
+import java.util.List;
+
+public interface CustomFeedCommentRepository {
+
+  List<FeedComment> findByCondition(FeedCommentSearchCondition condition);
+}

--- a/src/main/java/com/example/ootd/domain/feed/repository/custom/impl/CustomFeedCommentRepositoryImpl.java
+++ b/src/main/java/com/example/ootd/domain/feed/repository/custom/impl/CustomFeedCommentRepositoryImpl.java
@@ -1,0 +1,58 @@
+package com.example.ootd.domain.feed.repository.custom.impl;
+
+import com.example.ootd.domain.feed.dto.request.FeedCommentSearchCondition;
+import com.example.ootd.domain.feed.entity.FeedComment;
+import com.example.ootd.domain.feed.entity.QFeedComment;
+import com.example.ootd.domain.feed.repository.custom.CustomFeedCommentRepository;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class CustomFeedCommentRepositoryImpl implements CustomFeedCommentRepository {
+
+  private final JPAQueryFactory jpaQueryFactory;
+  private final QFeedComment qFeedComment = QFeedComment.feedComment;
+
+  @Override
+  public List<FeedComment> findByCondition(FeedCommentSearchCondition condition) {
+
+    return jpaQueryFactory
+        .select(qFeedComment).distinct()
+        .from(qFeedComment)
+        .where(cursorCondition(condition))
+        .orderBy(
+            qFeedComment.createdAt.asc(),
+            qFeedComment.id.asc()
+        )
+        .limit(condition.limit() + 1)
+        .fetch();
+  }
+
+  /**
+   * where절
+   */
+  private BooleanExpression cursorCondition(FeedCommentSearchCondition condition) {
+
+    if (condition.cursor() != null) {
+      return qFeedComment.createdAt.gt(condition.cursor())
+          .or(qFeedComment.createdAt.eq(condition.cursor())
+              .and(afterCondition(condition.idAfter())));
+    }
+
+    return afterCondition(condition.idAfter());
+  }
+
+  private BooleanExpression afterCondition(UUID idAfter) {
+
+    if (idAfter == null) {
+      return null;
+    }
+
+    return qFeedComment.id.gt(idAfter);
+  }
+}

--- a/src/main/java/com/example/ootd/domain/feed/repository/custom/impl/CustomFeedRepositoryImpl.java
+++ b/src/main/java/com/example/ootd/domain/feed/repository/custom/impl/CustomFeedRepositoryImpl.java
@@ -89,7 +89,7 @@ public class CustomFeedRepositoryImpl implements CustomFeedRepository {
 
     boolean isDesc = "DESCENDING".equalsIgnoreCase(condition.sortDirection());
 
-    if (!StringUtils.hasText(condition.cursor())) {
+    if (StringUtils.hasText(condition.cursor())) {
       switch (condition.sortBy()) {
         case "createdAt":
           LocalDateTime cursorCreatedAt = LocalDateTime.parse(condition.cursor());

--- a/src/main/java/com/example/ootd/domain/feed/service/FeedService.java
+++ b/src/main/java/com/example/ootd/domain/feed/service/FeedService.java
@@ -37,7 +37,7 @@ public interface FeedService {
   FeedDto likeFeed(UUID feedId, UUID userId);
 
   // 피드 좋아요 취소
-  FeedDto deleteFeedLike(UUID feedId, UUID userId);
+  void deleteFeedLike(UUID feedId, UUID userId);
 
   /**
    * 피드 댓글

--- a/src/main/java/com/example/ootd/domain/feed/service/impl/FeedServiceImpl.java
+++ b/src/main/java/com/example/ootd/domain/feed/service/impl/FeedServiceImpl.java
@@ -35,7 +35,6 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -223,8 +222,7 @@ public class FeedServiceImpl implements FeedService {
 
     log.debug("피드 댓글 목록 조회 시작: {}", condition);
 
-    List<FeedComment> comments = feedCommentRepository.findByCondition(feedId, condition.cursor(),
-        condition.idAfter(), PageRequest.ofSize(condition.limit()));
+    List<FeedComment> comments = feedCommentRepository.findByCondition(condition);
     List<CommentDto> commentDtos = commentMapper.toDto(comments);
 
     boolean hasNext = (comments.size() > condition.limit());

--- a/src/main/java/com/example/ootd/domain/image/service/impl/ImageServiceImpl.java
+++ b/src/main/java/com/example/ootd/domain/image/service/impl/ImageServiceImpl.java
@@ -24,6 +24,10 @@ public class ImageServiceImpl implements ImageService {
   @Override
   public Image upload(MultipartFile image) {
 
+    if (image == null) {
+      return null;
+    }
+
     Image saveImage = s3Service.save(image);
     imageRepository.save(saveImage);
 


### PR DESCRIPTION
## 🛰️ Issue Number
#94 

## 🪐 작업 내용
- FeedController 작성
- 포스트맨 테스트 및 코드 수정
- 피드 댓글 목록 조회 jpql -> queryDsl로 변경 (idAfter, cursor null 처리 용이하게 하기 위함)

## 📚 Reference

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
