### PR TITLE
[FIX] : 강수 확률 퍼센트 고치기

### DIFF
--- a/src/main/java/com/example/ootd/domain/weather/mapper/WeatherMapper.java
+++ b/src/main/java/com/example/ootd/domain/weather/mapper/WeatherMapper.java
@@ -26,7 +26,7 @@ public class WeatherMapper {
         new PrecipitationDto(
             weather.getPrecipitation().getPrecipitationType(),
             weather.getPrecipitation().getPrecipitationAmount(),
-            weather.getPrecipitation().getPrecipitationProbability()
+            weather.getPrecipitation().getPrecipitationProbability() / 100
         ),
         new HumidityDto(
             weather.getHumidity().getHumidityCurrent(),


### PR DESCRIPTION
## 🛰️ Issue Number

## 🪐 작업 내용

- 강수 확률이 아래와 같이 이상하게 나옴
<img width="362" height="675" alt="스크린샷 2025-07-15 093038" src="https://github.com/user-attachments/assets/dcf7bf68-70af-40b8-a86e-ac83212529a6" />

- 확인결과 프로토 타입 사이트에서는 소수점 단위로 표기하고 있음
<img width="311" height="740" alt="스크린샷 2025-07-15 093059" src="https://github.com/user-attachments/assets/9b48f382-b3bf-4138-bacd-9364965c4179" />

- 현재 상황
<img width="220" height="117" alt="스크린샷 2025-07-15 093241" src="https://github.com/user-attachments/assets/a2d3779d-1e5a-4d7c-babd-2034bf7280f1" />

- 프로토 타입 사이트
<img width="246" height="107" alt="스크린샷 2025-07-15 093257" src="https://github.com/user-attachments/assets/a7d27613-2ed7-45a0-9fa9-d595812a90ba" />

api에서 애초에 정수로 보내기 때문에 그냥 mapper 클래스에 /100을 하여 반환할때만 소숫점으로 보낼 수 있게 변경

## 📚 Reference

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
